### PR TITLE
Change arduino.h include to Arduino.h to make it work with Sketch on …

### DIFF
--- a/Frimwares/Source code/Hardware Version 2.0 (HW2.0)/NixieClockShield_NCS314/doIndication314_HW2.x.h
+++ b/Frimwares/Source code/Hardware Version 2.0 (HW2.0)/NixieClockShield_NCS314/doIndication314_HW2.x.h
@@ -1,7 +1,7 @@
 #ifndef __DOINDICATION_H
 #define __DOINDICATION_H
 //#include <stdint.h>
-#include <arduino.h>
+#include <Arduino.h>
 unsigned int SymbolArray[10]={1, 2, 4, 8, 16, 32, 64, 128, 256, 512};
 const unsigned int fpsLimit=16666;
 const byte LEpin=10;


### PR DESCRIPTION
I'm using Sketch on Linux, and the code failed to compile with an error like 
 fatal error: arduino.h: No such file
Changing the first letter made it work.