### PR TITLE
Removed call to adjustTime() between calls to setTime() and hour().

### DIFF
--- a/Firmware/Source code/Hardware Version 2.0 (HW2.0)/NixieClockShield_NCS314/NixieClockShield_NCS314.ino
+++ b/Firmware/Source code/Hardware Version 2.0 (HW2.0)/NixieClockShield_NCS314/NixieClockShield_NCS314.ino
@@ -1295,10 +1295,12 @@ void SyncWithGPS()
     Serial.println(fix.dateTime.minutes);
     Serial.println(fix.dateTime.seconds);
 
-    //setTime(GPS_Date_Time.GPS_hours, GPS_Date_Time.GPS_minutes, GPS_Date_Time.GPS_seconds, GPS_Date_Time.GPS_day, GPS_Date_Time.GPS_mounth, GPS_Date_Time.GPS_year % 1000);
-    setTime(fix.dateTime.hours, fix.dateTime.minutes, fix.dateTime.seconds, fix.dateTime.date, fix.dateTime.month, fix.dateTime.year);
-    if (gps.UTCms()>=500) adjustTime(1);
-    adjustTime((long)value[HoursOffsetIndex] * 3600);
+    const uint8_t tmYear = y2kYearToTm(fix.dateTime.year);
+    tmElements_t tm = { fix.dateTime.seconds, fix.dateTime.minutes, fix.dateTime.hours,
+                        0, fix.dateTime.date, fix.dateTime.month, tmYear };
+    time_t localtime = makeTime(tm) + value[HoursOffsetIndex] * 3600;
+    if (gps.UTCms()>=500) ++localtime;
+    setTime(localtime);
     setRTCDateTime(hour(), minute(), second(), day(), month(), year() % 1000, 1);
     GPS_Sync_Flag = 1;
     Last_Time_GPS_Sync = millis();

--- a/Firmware/Source code/Hardware Version 3.x (HW3.2)/NixieClockShield_NCS314/NixieClockShield_NCS314.ino
+++ b/Firmware/Source code/Hardware Version 3.x (HW3.2)/NixieClockShield_NCS314/NixieClockShield_NCS314.ino
@@ -1308,11 +1308,12 @@ void SyncWithGPS()
    // Serial.print("offset=");
     //Serial.print(offset);
 
-    setTime(fix.dateTime.hours, fix.dateTime.minutes, fix.dateTime.seconds, fix.dateTime.date, fix.dateTime.month, fix.dateTime.year);
+    const uint8_t tmYear = y2kYearToTm(fix.dateTime.year);
+    tmElements_t tm = { fix.dateTime.seconds, fix.dateTime.minutes, fix.dateTime.hours,
+                        0, fix.dateTime.date, fix.dateTime.month, tmYear };
+    time_t localtime = makeTime(tm) + value[HoursOffsetIndex] * 3600 + 1;
     //if (gps.UTCms()>=500) adjustTime(1);
-    //adjustTime(offset);
-    adjustTime(1);
-    adjustTime((long)value[HoursOffsetIndex] * 3600);
+    setTime(localtime);
     setRTCDateTime(hour(), minute(), second(), day(), month(), year() % 1000, 1);
     GPS_Sync_Flag = 1;
     Last_Time_GPS_Sync = millis();


### PR DESCRIPTION
This fixes occasional failure to reflect time zone (HoursOffset)
after updating the time from GPS.  The Time library contains a
refreshCache() function that updates the cache only if the time
has changed since the last cache update.

adjustTime does not call refreshCache().  hour() does call it, with
the current time.  If the current time is the same as the cached time
from the setTime() call, then the cache of tm is not updated to reflect
the adjustTime() call.  Then, the timezone adjustment is ignored.